### PR TITLE
Bugfix: result of 0 4mers not caught if sequence length == 3

### DIFF
--- a/pkg/obikmer/encodefourmer.go
+++ b/pkg/obikmer/encodefourmer.go
@@ -47,7 +47,7 @@ func Encode4mer(seq *obiseq.BioSequence, buffer *[]byte) []byte {
 	length := slength - 3
 	rawseq := seq.Sequence()
 
-	if length < 0 {
+	if length <= 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Based on repeating runtime panics with out of range indices (e.g. issue #69 ), I believe I found unexpected behaviour where the assignment of 4mers is run on sequences of length 3. 

In the 4mer calculation:

length := slength - 3

For sequences with <4 bases, length is <=0

The check to stop did only catch <0, so sequences lengths 2 or less, leaving sequence lengths of 3 unguarded and thus a panic when trying to access the missing 4th base

if length < 0 {
    return nil
}

Changed "<" to "<="
	